### PR TITLE
[chore] add netlify.toml including basic url rewrite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  publish = "build/"
+  command = "npm run build"
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
This PR adds the `netlify.toml` with the build config + a url rewrite from `/*` to `/` in order to let the internal router work.